### PR TITLE
Rognir will now slow down as his dash ends.

### DIFF
--- a/NPCs/Rognir/RognirBoss.cs
+++ b/NPCs/Rognir/RognirBoss.cs
@@ -336,7 +336,7 @@ namespace Rognir.NPCs.Rognir
 				dashTimer--;
 
 				// Get the speed of the dash and limit it.
-				float speed = dashDirection.Length();
+				float speed = dashTimer;
 				if (speed > rogDashSpeedOne && stage == 1)
 				{
 					speed = rogDashSpeedOne;


### PR DESCRIPTION
Rognir will now slow down as his dash ends.  Rather than calculating the dash speed based on the distance to the player, the dash speed is now based  on the dash timer that counts down each tick that the dash is active.  