### PR TITLE
Fixed an namespace issue with the dusts.

### DIFF
--- a/Dusts/Bubble.cs
+++ b/Dusts/Bubble.cs
@@ -2,7 +2,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
 
-namespace ExampleMod.Dusts
+namespace Rognir.Dusts
 {
 	public class Bubble : ModDust
 	{

--- a/Dusts/EtherealFlame.cs
+++ b/Dusts/EtherealFlame.cs
@@ -2,7 +2,7 @@ using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ModLoader;
 
-namespace ExampleMod.Dusts
+namespace Rognir.Dusts
 {
 	public class EtherealFlame : ModDust
 	{


### PR DESCRIPTION
The Ethereal Flame and Bubble dust both had the namespace set to ExampleMod.Dusts.  I changed this to Rognir.Dusts